### PR TITLE
Fix _arguments:comparguments:325 error

### DIFF
--- a/etc/zsh/_bloop
+++ b/etc/zsh/_bloop
@@ -81,7 +81,7 @@ _project_or_flags() {
     fi
 }
 
-_arguments \
+_arguments >/dev/null 2>&1  \
     ":command:_commands" \
     ":project_or_flags:_project_or_flags" \
     "*::flags:_tests_or_flags"


### PR DESCRIPTION
Remove `_arguments:comparguments:325: can only be called from completion function` error